### PR TITLE
Add items and vehicle parts to the flag screen

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -124,6 +124,7 @@ function maybeFocusSearch(e: KeyboardEvent) {
       <li><a href="#/furniture">Furniture</a></li>
       <li><a href="#/vehicle_part">Vehicle Parts</a></li>
       <li><a href="#/tool_quality">Qualities</a></li>
+      <li><a href="#/json_flag">Flags</a></li>
     </ul>
   {/if}
 

--- a/src/types/Flag.svelte
+++ b/src/types/Flag.svelte
@@ -1,12 +1,55 @@
 <script lang="ts">
-import type { JsonFlag } from "../types";
+import { getContext } from "svelte";
+import { CddaData, singularName } from "../data";
+import type { Item, VehiclePart, JsonFlag } from "../types";
+import ThingLink from "./ThingLink.svelte";
 
 export let item: JsonFlag
+
+let data = getContext<CddaData>('data')
+
+let itemsWithFlag = new Array<Item>()
+for (const it of data.byType<Item>('item')) {
+  if (!it.id) continue;
+  const q = (it.flags ?? []).find(id => id === item.id)
+  if (q) {
+    itemsWithFlag.push(it)
+  }
+}
+
+let vpartsWithFlag = new Array<VehiclePart>()
+for (const it of data.byType<VehiclePart>('vehicle_part')) {
+  if (!it.id) continue;
+  const q = (it.flags ?? []).find(id => id === item.id)
+  if (q) {
+    vpartsWithFlag.push(it)
+  }
+}
 </script>
 
 <h1>Flag: {item.id}</h1>
 {#if item.info}
 <section>
   <p style="color: var(--cata-color-gray)">{item.info}</p>
+</section>
+{/if}
+{#if itemsWithFlag.length}
+<section>
+  <h1>Items</h1>
+  <ul>
+    {#each itemsWithFlag.sort((a, b) => singularName(a).localeCompare(singularName(b))) as {id}}
+    <li><ThingLink type="item" {id} /></li>
+    {/each}
+  </ul>
+</section>
+{/if}
+{#if vpartsWithFlag.length}
+<section>
+  <h1>Vehicle Parts</h1>
+  <ul>
+    {#each vpartsWithFlag.sort((a, b) => singularName(a).localeCompare(singularName(b))) as {id}}
+    <li><ThingLink type="vehicle_part" {id} /></li>
+    {/each}
+  </ul>
 </section>
 {/if}


### PR DESCRIPTION
Adds the feature requested in #17. When you open up a flag, every item and vehicle part that has it is listed. Also adds Flags to the links on the home screen.

The code was really easy to pick up and edit, even for someone who hadn't used the technologies before! Hopefully my changes are all in good order.