### PR TITLE
Allow viewing of flags with no json_flag entry

### DIFF
--- a/src/Thing.svelte
+++ b/src/Thing.svelte
@@ -22,8 +22,16 @@ export let item: { id: string, type: string }
 export let data: CddaData
 setContext('data', data)
 
+function defaultItem(id : string, type : string) {
+  if (type == 'json_flag') {
+    return { id: id, type: type }
+  } else {
+    return null
+  }
+}
+
 let obj: any;
-$: obj = data.byId(item.type, item.id)
+$: obj = data.byId(item.type, item.id) ?? defaultItem(item.id, item.type)
 
 const displays = {
   MONSTER: Monster,

--- a/src/Thing.svelte
+++ b/src/Thing.svelte
@@ -22,9 +22,9 @@ export let item: { id: string, type: string }
 export let data: CddaData
 setContext('data', data)
 
-function defaultItem(id : string, type : string) {
-  if (type == 'json_flag') {
-    return { id: id, type: type }
+function defaultItem(id: string, type: string) {
+  if (type === 'json_flag') {
+    return { id, type }
   } else {
     return null
   }


### PR DESCRIPTION
My previous change can't list certain flags because they don't actually exist in flags.json (Unknown obj: json_flag/FOLDABLE). This commit adds a little hack to create a default object so undocumented flags can be rendered. The code can be extended to other types if it happens anywhere else.

This doesn't make them show up in the catalog. Piling on additional hacks (hardcoding a list in Catalog.svelte, hardcoding them in  the data, building a set at runtime by searching the whole database) could resolve that, but I'm not sure how far we'd want to go with it. Maybe I should go upstream and see if they can be added to the json file?