### PR TITLE
[WIP] Display probabilities in the LOOT section

### DIFF
--- a/src/types/item/IsolatedSpawnedIn.svelte
+++ b/src/types/item/IsolatedSpawnedIn.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+import { setContext } from "svelte"
+import SpawnedIn from './SpawnedIn.svelte'
+import { CddaData } from '../../data'
+import * as fs from 'fs'
+
+const json = JSON.parse(fs.readFileSync(__dirname + '/../../../_test/all.json', 'utf8'))
+const data: CddaData = new CddaData(json.data)
+setContext('data', data)
+
+</script>
+
+<SpawnedIn {...$$restProps}/>

--- a/src/types/item/SpawnedIn.test.ts
+++ b/src/types/item/SpawnedIn.test.ts
@@ -1,0 +1,7 @@
+import { render } from '@testing-library/svelte'
+
+import IsolatedSpawnedIn from './IsolatedSpawnedIn.svelte'
+
+test('TODO', () => {
+  render(IsolatedSpawnedIn, {item_id: "fake_item"})
+})


### PR DESCRIPTION
Currently the LOOT section displays all the locations where an item can be found ordered alphabetically and does not display the probability of finding the item in a given location. This is not very helpful because the locations with very low chances of spawning the item are mixed with the ones with much higher chances.

I'm going to:
1. Show the spawn probability
2. Sort by spawn probability