### PR TITLE
add holster flag to pocket info display

### DIFF
--- a/src/types/Item.svelte
+++ b/src/types/Item.svelte
@@ -381,7 +381,8 @@ const ascii_picture =
         <dt>Moves to Remove Item</dt>
         <dd>{pocket.moves}</dd>
         {#if pocket.holster}
-          <dt title="This pocket can only hold one item.">Holster</dt>
+          <dt>Max Items</dt>
+          <dd>1</dd>
         {/if}
         {#if (pocket.sealed_data?.spoil_multiplier ?? 1) !== 1.0}
           <dt>Spoil Multiplier</dt>

--- a/src/types/Item.svelte
+++ b/src/types/Item.svelte
@@ -380,6 +380,9 @@ const ascii_picture =
         {/if}
         <dt>Moves to Remove Item</dt>
         <dd>{pocket.moves}</dd>
+        {#if pocket.holster}
+          <dt title="This pocket can only hold one item.">Holster</dt>
+        {/if}
         {#if (pocket.sealed_data?.spoil_multiplier ?? 1) !== 1.0}
           <dt>Spoil Multiplier</dt>
           <dd>{pocket.sealed_data.spoil_multiplier}</dd>


### PR DESCRIPTION
![Screen Shot 2022-02-04 at 11 30 00 PM](https://user-images.githubusercontent.com/385684/152632996-4e87b25b-c639-4222-a0f1-c6c5065ec932.png)

I tried to put two guns in my survior harness but they both couldn't go in. Turns out the large pocket is flagged as a "holster," which means only one item can go in. This info seems useful to know and I don't think it's available in the game, but now it's available on the guide :)