### PR TITLE
fix: reword build and tiles options

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -345,7 +345,7 @@ Anyway?`,
   {/if}
 
   <p>
-    {t("Build:")}
+    {t("Version:")}
     {#if $data || builds}
       {#if builds}
         <!-- svelte-ignore a11y-no-onchange -->
@@ -381,7 +381,7 @@ Anyway?`,
       <em style="color: var(--cata-color-gray)">({t("Loading...")})</em>
     {/if}
     <span style="white-space: nowrap">
-      {t("Tiles:")}
+      {t("Tileset:")}
       <!-- svelte-ignore a11y-no-onchange -->
       <select
         value={tilesetUrlTemplate}


### PR DESCRIPTION
Using "Build" to describe your target version of the game isn't ideal;
change it to "Version" since that more accurately describes what that
option changes
Same with "Tiles" "Tileset" is more accurate

Ran into this while translating the guide