### PR TITLE
fix computation of melee and ranged coverage

### DIFF
--- a/src/types/item/ArmorInfo.svelte
+++ b/src/types/item/ArmorInfo.svelte
@@ -73,9 +73,10 @@ for (const apd of item.armor ?? []) {
       const scale = maxCoverage(bp, apd) / 100;
       const existingScale = maxCoverage(bp, existing) / 100;
 
-      existing.coverage += ((apd.coverage ?? 0) * scale) | 0;
-      existing.cover_melee += ((apd.cover_melee ?? 0) * scale) | 0;
-      existing.cover_ranged += ((apd.cover_ranged ?? 0) * scale) | 0;
+      const baseCoverage = apd.coverage ?? 0;
+      existing.coverage += (baseCoverage * scale) | 0;
+      existing.cover_melee += ((apd.cover_melee ?? baseCoverage) * scale) | 0;
+      existing.cover_ranged += ((apd.cover_ranged ?? baseCoverage) * scale) | 0;
       existing.cover_vitals =
         (existing.cover_vitals ?? 0) + (apd.cover_vitals ?? 0);
 


### PR DESCRIPTION
Armors which define multiple coverage values for different sublocations weren't falling back on the default coverage value for that location when no cover_melee and cover_ranged values were set.  This could be seen in the tshirt, where it would display separate and bogus values for melee and ranged coverage even though no such coverages were defined in the JSON.