### PR TITLE
move gas station bunker and bunker shop to hidden locations

### DIFF
--- a/src/types/item/spawnLocations.ts
+++ b/src/types/item/spawnLocations.ts
@@ -264,6 +264,8 @@ const hiddenLocations = showAll
       "nuclear power plant",
       "tutorial",
       "debug_item_group_test",
+      "gas station bunker",
+      "bunker shop",
     ]);
 const lootByOmAppearanceCache = new WeakMap<
   CddaData,


### PR DESCRIPTION
It is not a particularly secret places, but with it's rarity, confusing name, and how often it happens to be at the top of the list for "this rare item", i think it would be better to hide it
screenshot of <https://cdda-guide.nornagon.net/furniture/f_compact_ASRG_containment>
![image](https://github.com/nornagon/cdda-guide/assets/67688115/39176f11-d51c-4b0b-88ea-2d05c1af674e)