### PR TITLE
feat(tests): enhance schema validation error messages with filename context

### DIFF
--- a/src/schema.test.ts
+++ b/src/schema.test.ts
@@ -1,7 +1,8 @@
 import * as TJS from "ts-json-schema-generator";
 import * as fs from "fs";
 import * as util from "util";
-import Ajv, { ValidateFunction } from "ajv";
+import Ajv from "ajv";
+import type { ValidateFunction } from "ajv";
 import { CddaData } from "./data";
 import { test, expect } from "vitest";
 
@@ -17,17 +18,19 @@ expect.extend({
   toMatchSchema(obj: any, schema: ValidateFunction) {
     const valid = schema(obj);
     const errors = schema.errors?.slice();
+    const filename = findFilename(obj, parentMap);
     return {
       pass: valid,
       message: () => {
         return (
-          errors
-            ?.map((e) => {
-              return `${e.instancePath} ${e.message}, but was ${util.inspect(
-                e.data
-              )}`;
-            })
-            .join("\n") ?? ""
+          (filename ? `[File: ${filename}]\n` : "") +
+            errors
+              ?.map((e) => {
+                return `${e.instancePath} ${e.message}, but was ${util.inspect(
+                  e.data
+                )}`;
+              })
+              .join("\n") ?? ""
         );
       },
     };
@@ -65,6 +68,36 @@ const id = (x: any) => {
   if (x.result) return x.result;
   if (x.om_terrain) return JSON.stringify(x.om_terrain);
 };
+
+const findFilename = (
+  obj: any,
+  parentMap: WeakMap<object, object | null>
+): string | undefined => {
+  let current: any = obj;
+
+  while (current) {
+    if (current.__filename) return current.__filename;
+    current = parentMap.get(current) || null; // Move up to parent
+  }
+  return undefined;
+};
+
+// Create a parent tracking map before validation
+const parentMap = new WeakMap<object, object | null>();
+
+const buildParentMap = (obj: any, parent: any = null) => {
+  if (typeof obj !== "object" || obj === null) return;
+  parentMap.set(obj, parent);
+  for (const key in obj) {
+    if (typeof obj[key] === "object" && obj[key] !== null) {
+      buildParentMap(obj[key], obj);
+    }
+  }
+};
+
+// Build parent-child relationships
+buildParentMap(data._raw);
+
 const all = data._raw
   .filter((x) => id(x))
   .filter((x) => schemasByType.has(x.type))


### PR DESCRIPTION
Adds a helper to the output message to assist in locating "invalid" JSON in in all.json.

Example output:

```
Error: [File: data/json/items/ammo/shot.json#L94-L109]
 must have required property 'id', but was {
  abstract: 'shotshell_abstract',
  type: 'AMMO',
  name: { str: 'base shotshell', '//~': 'NO_I18N' },
  weight: '47 g',
  volume: '377 ml',
  longest_side: '57 mm',
  flags: [ 'IRREPLACEABLE_CONSUMABLE' ],
  material: [ 'brass', 'plastic', 'lead', 'powder' ],
  symbol: '=',
  color: 'red',
  count: 20,
  stack_size: 20,
  ammo_type: 'shot',
  casing: 'shot_hull',
  __filename: 'data/json/items/ammo/shot.json#L94-L109'
}
```