### PR TITLE
Fix incorrect trash group for foraging

### DIFF
--- a/src/types/item/Foraged.svelte
+++ b/src/types/item/Foraged.svelte
@@ -14,7 +14,7 @@ const forageGroups = {
   Summer: "forage_summer",
   Autumn: "forage_autumn",
   Winter: "forage_winter",
-  "any season": "trash_forest",
+  "any season": "SUS_trash_no_manmade",
 };
 
 const forageable = Object.entries(forageGroups)


### PR DESCRIPTION
https://github.com/CleverRaven/Cataclysm-DDA/pull/79848 replaced `trash_forest` group for foraging with SUS_trash_no_manmade group, this PR does the same for HHG

I am afraid it would need more advanced logic, because it would ruin the HHG ability to parse itemgroups for all previous releases