### PR TITLE
Fix Ammunition Type variant listing

### DIFF
--- a/src/types/AmmunitionType.svelte
+++ b/src/types/AmmunitionType.svelte
@@ -4,7 +4,8 @@ import { t } from "@transifex/native";
 import { getContext } from "svelte";
 import { byName, CddaData, singularName } from "../data";
 import LimitedList from "../LimitedList.svelte";
-import type { AmmunitionType, Item } from "../types";
+import type { AmmunitionType, Item, ItemSubtypeToSlot } from "../types";
+import { isItemSubtype } from "../types";
 import ItemSymbol from "./item/ItemSymbol.svelte";
 import ThingLink from "./ThingLink.svelte";
 
@@ -14,11 +15,12 @@ const _context = "Ammunition Type";
 
 const data = getContext<CddaData>("data");
 
-const compatible = data.byType("item").flatMap((x) => {
-  if (x.type !== "AMMO" || !x.id) return [];
-  if (x.ammo_type === item.id) return [x];
-  return [];
-});
+const compatible = data
+  .byType("item")
+  .filter(
+    (x): x is Item & ItemSubtypeToSlot["AMMO"] =>
+      !!x.id && isItemSubtype("AMMO", x) && x.ammo_type === item.id
+  );
 compatible.sort(byName);
 
 const usesAmmoType = (w: Item, t: AmmunitionType): boolean => {

--- a/src/types/AmmunitionType.test.ts
+++ b/src/types/AmmunitionType.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, cleanup } from "@testing-library/svelte";
+import { describe, it, expect, afterEach } from "vitest";
+
+import AmmunitionType from "./AmmunitionType.svelte";
+import WithData from "../WithData.svelte";
+import { CddaData } from "../data";
+
+afterEach(cleanup);
+
+describe("AmmunitionType compatible variants", () => {
+  it("lists ammo items that share the ammo_type", () => {
+    const data = new CddaData([
+      { type: "ammunition_type", id: "22", name: "22", default: "22_lr" },
+      {
+        type: "ITEM",
+        id: "22_lr",
+        name: ".22 LR",
+        subtypes: ["AMMO"],
+        ammo_type: "22",
+      },
+      {
+        type: "ITEM",
+        id: "22_hp",
+        name: ".22 HP",
+        subtypes: ["AMMO"],
+        ammo_type: "22",
+      },
+      {
+        type: "AMMO",
+        id: "22_sp",
+        name: ".22 SP",
+        ammo_type: "22",
+      },
+      {
+        type: "ITEM",
+        id: "dummy_mag",
+        name: "dummy mag",
+        subtypes: ["MAGAZINE"],
+        ammo_type: "22",
+      },
+    ]);
+
+    const { getByText, queryByText } = render(WithData, {
+      Component: AmmunitionType,
+      item: data.byId("ammunition_type", "22"),
+      data,
+    });
+
+    expect(getByText(/\.22 LR/)).toBeTruthy();
+    expect(getByText(/\.22 HP/)).toBeTruthy();
+    expect(getByText(/\.22 SP/)).toBeTruthy();
+    expect(queryByText(/dummy mag/)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- show ammo variants for legacy `AMMO` items and modern `ITEM` subtypes
- unit test covers both item forms

## Testing
- `npx vitest run src/types/AmmunitionType.test.ts`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686dd363be00833299d67ef51ce4bdbd