### PR TITLE
Handle object-style material definitions

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -618,7 +618,7 @@ export class CddaData {
           if (ret.replace_materials[mats]) {
             ret.material = ret.replace_materials[mats];
           }
-        } else {
+        } else if (Array.isArray(mats)) {
           ret.material = mats.map((x) => {
             if (typeof x === "string") {
               return ret.replace_materials[x] ?? x;
@@ -629,6 +629,13 @@ export class CddaData {
               return x;
             }
           });
+        } else {
+          ret.material = Object.fromEntries(
+            Object.entries(mats).map(([k, v]) => [
+              ret.replace_materials[k] ?? k,
+              v,
+            ])
+          );
         }
         // TODO: update weight
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -636,7 +636,11 @@ export type ItemBasicInfo = {
   volume?: volume;
   weight?: mass;
   longest_side?: string;
-  material?: string | string[] | { type: string; portion?: integer }[]; // material_id
+  material?:
+    | string
+    | string[]
+    | { type: string; portion?: integer }[]
+    | Record<string, number>; // material_id
   flags?: string | string[];
   faults?: (string | { fault: string } | { fault_group: string })[];
   pocket_data?: PocketData[];

--- a/src/types/Item.svelte
+++ b/src/types/Item.svelte
@@ -80,16 +80,21 @@ let chargedQualities = (item.charged_qualities ?? []).map(([id, level]) => ({
 }));
 
 function isStrings<T>(array: string[] | T[]): array is string[] {
-  return typeof array[0] === "string";
+  return Array.isArray(array) && typeof array[0] === "string";
 }
 const materials =
   item.material == null
     ? []
     : typeof item.material === "string"
     ? [{ type: item.material, portion: 1 }]
-    : isStrings(item.material)
-    ? item.material.map((s) => ({ type: s, portion: 1 }))
-    : item.material.map((s) => ({ type: s.type, portion: s.portion ?? 1 }));
+    : Array.isArray(item.material)
+    ? isStrings(item.material)
+      ? item.material.map((s) => ({ type: s, portion: 1 }))
+      : item.material.map((s) => ({ type: s.type, portion: s.portion ?? 1 }))
+    : Object.entries(item.material).map(([type, portion]) => ({
+        type,
+        portion: portion as number,
+      }));
 const totalMaterialPortion = materials.reduce((m, o) => m + o.portion, 0);
 const primaryMaterial = materials.reduce(
   (m, o) => (!m || o.portion > m.portion ? o : m),

--- a/src/types/Material.svelte
+++ b/src/types/Material.svelte
@@ -21,7 +21,7 @@ export let item: Material;
 const _context = "Material";
 
 function isStrings<T>(array: string[] | T[]): array is string[] {
-  return typeof array[0] === "string";
+  return Array.isArray(array) && typeof array[0] === "string";
 }
 
 let itemsWithMaterial = data
@@ -32,9 +32,11 @@ let itemsWithMaterial = data
         ? []
         : typeof i.material === "string"
         ? [i.material]
-        : isStrings(i.material)
-        ? i.material
-        : i.material.map((m) => m.type);
+        : Array.isArray(i.material)
+        ? isStrings(i.material)
+          ? i.material
+          : i.material.map((m) => m.type)
+        : Object.keys(i.material);
     return i.id && normalizedMaterial.some((m) => m === item.id);
   })
   .sort(byName);

--- a/src/types/item/ArmorInfo.svelte
+++ b/src/types/item/ArmorInfo.svelte
@@ -33,16 +33,21 @@ function normalizeApdMaterial(m: NonNullable<ArmorPortionData["material"]>[0]) {
 }
 
 function isStrings<T>(array: string[] | T[]): array is string[] {
-  return typeof array[0] === "string";
+  return Array.isArray(array) && typeof array[0] === "string";
 }
 const itemMaterials =
   item.material == null
     ? []
     : typeof item.material === "string"
     ? [{ type: item.material, portion: 1 }]
-    : isStrings(item.material)
-    ? item.material.map((s) => ({ type: s, portion: 1 }))
-    : item.material.map((s) => ({ portion: 1, ...s }));
+    : Array.isArray(item.material)
+    ? isStrings(item.material)
+      ? item.material.map((s) => ({ type: s, portion: 1 }))
+      : item.material.map((s) => ({ portion: 1, ...s }))
+    : Object.entries(item.material).map(([type, portion]) => ({
+        type,
+        portion: portion as number,
+      }));
 const totalMaterialPortion = itemMaterials.reduce((m, o) => m + o.portion, 0);
 
 const normalizedPortionData: (ArmorPortionData & {

--- a/src/types/item/ArmorInfo0F.svelte
+++ b/src/types/item/ArmorInfo0F.svelte
@@ -7,7 +7,7 @@ export let item: ItemBasicInfo & ArmorSlot;
 let data = getContext<CddaData>("data");
 
 function isStrings<T>(array: string[] | T[]): array is string[] {
-  return typeof array[0] === "string";
+  return Array.isArray(array) && typeof array[0] === "string";
 }
 
 const normalizedMaterial =
@@ -15,9 +15,14 @@ const normalizedMaterial =
     ? []
     : typeof item.material === "string"
     ? [{ type: item.material, portion: 1 }]
-    : isStrings(item.material)
-    ? item.material.map((s) => ({ type: s, portion: 1 }))
-    : item.material;
+    : Array.isArray(item.material)
+    ? isStrings(item.material)
+      ? item.material.map((s) => ({ type: s, portion: 1 }))
+      : item.material
+    : Object.entries(item.material).map(([type, portion]) => ({
+        type,
+        portion: portion as number,
+      }));
 
 let materials = normalizedMaterial.map((m) => ({
   material: data.byId("material", m.type),

--- a/src/types/item/Salvaged.svelte
+++ b/src/types/item/Salvaged.svelte
@@ -20,7 +20,15 @@ function itemsWithOnlyMaterial(soughtMat: Material): Item[] {
     .filter((it) => it.id)
     .filter((it) => {
       const mat =
-        typeof it.material === "string" ? [it.material] : it.material ?? [];
+        it.material == null
+          ? []
+          : typeof it.material === "string"
+          ? [it.material]
+          : Array.isArray(it.material)
+          ? typeof it.material[0] === "string"
+            ? it.material
+            : it.material.map((m) => (typeof m === "string" ? m : m.type))
+          : Object.keys(it.material);
       return mat.length === 1 && mat[0] === soughtMat.id;
     });
 }


### PR DESCRIPTION
## Summary
- support object-based `material` definitions in data loading and Svelte components
- normalize material lists across item and armor views to avoid `.map` errors
- broaden ItemBasicInfo material typing

## Testing
- `npm run lint`
- `npm run validate`
- `TEST_ONLY=item/boots_wsurvivor_nofur npx vitest run src/all.1.test.ts --reporter=default`
- `TEST_ONLY=item/latrunculi npx vitest run src/all.1.test.ts --reporter=default`
- `TEST_ONLY=material/steel npx vitest run src/all.1.test.ts --reporter=default`

------
https://chatgpt.com/codex/tasks/task_e_688e2f0e011083328bd4c64bc16548f3