### PR TITLE
Fix book recipe list

### DIFF
--- a/src/types/item/BookInfo.svelte
+++ b/src/types/item/BookInfo.svelte
@@ -19,14 +19,16 @@ function add(recipe_id: string, level: number) {
   );
 }
 for (const recipe of data.byType("recipe")) {
-  if (recipe.result && Array.isArray(recipe.book_learn))
+  if (!recipe.result) continue;
+  if (Array.isArray(recipe.book_learn)) {
     for (const [id, level = 0] of recipe.book_learn)
       if (id === item.id) add(recipe.result, level);
-      else if (recipe.book_learn)
-        for (const [id, obj] of Object.entries(
-          recipe.book_learn as Record<string, any>
-        ))
-          if (id === item.id) add(recipe.result, obj.skill_level ?? 0);
+  } else if (recipe.book_learn) {
+    for (const [id, obj] of Object.entries(
+      recipe.book_learn as Record<string, any>
+    ))
+      if (id === item.id) add(recipe.result, obj.skill_level ?? 0);
+  }
 }
 </script>
 


### PR DESCRIPTION
This PR fixes the bug where the recipe list in the book info is incomplete.

e.g.
The page [cooked bamboo shoots](https://cdda-guide.nornagon.net/item/bamboo_cooked) writes `Written In: Sushi Made Easy (2), family cookbook (2)`; while you can't find it in either book: [Sushi Made Easy](https://cdda-guide.nornagon.net/item/cookbook_sushi), [family cookbook](https://cdda-guide.nornagon.net/item/family_cookbook).