### PR TITLE
Centralize and expand spoiler handling

### DIFF
--- a/src/SearchResults.svelte
+++ b/src/SearchResults.svelte
@@ -26,6 +26,7 @@ import {
   getOMSByAppearance,
   overmapAppearance,
 } from "./types/item/spawnLocations";
+import { isSpoilerItem } from "./spoilers";
 
 const SEARCHABLE_TYPES = new Set<keyof SupportedTypesWithMapped>([
   "item",
@@ -116,7 +117,8 @@ $: targets = [...(data?.all() ?? [])]
         type: mapType(x.type),
       }))
     )
-  );
+  )
+  .filter((x) => !isSpoilerItem(x.id));
 
 export let search: string;
 

--- a/src/Thing.svelte
+++ b/src/Thing.svelte
@@ -36,6 +36,9 @@ import OvermapSpecial from "./types/OvermapSpecial.svelte";
 import ItemAction from "./types/ItemAction.svelte";
 import Technique from "./types/Technique.svelte";
 
+import Spoiler from "./Spoiler.svelte";
+import { isSpoilerItem } from "./spoilers";
+
 export let item: { id: string; type: string };
 
 export let data: CddaData;
@@ -145,7 +148,9 @@ const display = (obj && displays[obj.type]) ?? Unknown;
       {#if /obsolet/.test(obj.__filename)}
         <ObsoletionWarning item={obj} />
       {/if}
-      <svelte:component this={display} item={obj} />
+      <Spoiler spoily={isSpoilerItem(item.id)}>
+        <svelte:component this={display} item={obj} />
+      </Spoiler>
     </ErrorBoundary>
   {/if}
 

--- a/src/spoilers.ts
+++ b/src/spoilers.ts
@@ -26,32 +26,33 @@ export function isSpoilerItem(id: string): boolean {
   return false;
 }
 
-export const HIDDEN_LOOT_LOCATIONS: ReadonlySet<string> = new Set(
-  showAll
-    ? []
-    : [
-        "Necropolis",
-        "Isherwood Farms",
-        "lab_mutagen_6_level",
-        "Lab_SECURITY_1x1x6",
-        "Lab_CARGO_Surface",
-        "hub_01",
-        "aircraft_carrier",
-        "airliner_crashed",
-        "farm_abandoned",
-        "ranch_camp",
-        "exodii_base",
-        "Central Lab",
-        "4x4_microlab_vent_shaft",
-        "lab_subway_vent_shaft",
-        "mil_base",
-        "valhalla_cult",
-        "nuclear power plant",
-        "tutorial",
-        "debug_item_group_test",
-        "gas station bunker",
-        "bunker shop",
-        "physics_lab_LIXA",
-        "office_tower_hiddenlab",
-      ]
-);
+const SPOILER_LOCATION_IDS: ReadonlySet<string> = new Set([
+  "Necropolis",
+  "Isherwood Farms",
+  "lab_mutagen_6_level",
+  "Lab_SECURITY_1x1x6",
+  "Lab_CARGO_Surface",
+  "hub_01",
+  "aircraft_carrier",
+  "airliner_crashed",
+  "farm_abandoned",
+  "ranch_camp",
+  "exodii_base",
+  "Central Lab",
+  "4x4_microlab_vent_shaft",
+  "lab_subway_vent_shaft",
+  "mil_base",
+  "valhalla_cult",
+  "nuclear power plant",
+  "tutorial",
+  "debug_item_group_test",
+  "gas station bunker",
+  "bunker shop",
+  "physics_lab_LIXA",
+  "office_tower_hiddenlab",
+]);
+
+export function isSpoilerLocation(id: string): boolean {
+  if (showAll) return false;
+  return SPOILER_LOCATION_IDS.has(id);
+}

--- a/src/spoilers.ts
+++ b/src/spoilers.ts
@@ -1,0 +1,57 @@
+// Centralised list of spoilery / visually-noisy content that is hidden by default.  Add new entries as needed.  Everything here is bypassed when the URL contains ?hideNothing.
+
+const showAll = new URL(location.href).searchParams.has("hideNothing");
+
+const SPOILER_PREFIXES: ReadonlySet<string> = new Set([
+  "f_vitrified_",
+  "f_glassedbody_",
+  "t_vitrified_",
+  "black_glass_",
+  "imperfect_doll_",
+]);
+
+const SPOILER_IDS: ReadonlySet<string> = new Set(["mon_dragon_dummy"]);
+
+const SPOILER_SUFFIXES: ReadonlySet<string> = new Set(["_vitrified"]);
+
+export function isSpoilerItem(id: string): boolean {
+  if (showAll) return false;
+  if (SPOILER_IDS.has(id)) return true;
+  for (const prefix of SPOILER_PREFIXES) {
+    if (id.startsWith(prefix)) return true;
+  }
+  for (const suffix of SPOILER_SUFFIXES) {
+    if (id.endsWith(suffix)) return true;
+  }
+  return false;
+}
+
+export const HIDDEN_LOOT_LOCATIONS: ReadonlySet<string> = new Set(
+  showAll
+    ? []
+    : [
+        "Necropolis",
+        "Isherwood Farms",
+        "lab_mutagen_6_level",
+        "Lab_SECURITY_1x1x6",
+        "Lab_CARGO_Surface",
+        "hub_01",
+        "aircraft_carrier",
+        "airliner_crashed",
+        "farm_abandoned",
+        "ranch_camp",
+        "exodii_base",
+        "Central Lab",
+        "4x4_microlab_vent_shaft",
+        "lab_subway_vent_shaft",
+        "mil_base",
+        "valhalla_cult",
+        "nuclear power plant",
+        "tutorial",
+        "debug_item_group_test",
+        "gas station bunker",
+        "bunker shop",
+        "physics_lab_LIXA",
+        "office_tower_hiddenlab",
+      ]
+);

--- a/src/types/Monster.svelte
+++ b/src/types/Monster.svelte
@@ -21,7 +21,6 @@ import type {
 } from "../types";
 import ItemSymbol from "./item/ItemSymbol.svelte";
 import SpecialAttack from "./monster/SpecialAttack.svelte";
-import Spoiler from "../Spoiler.svelte";
 import ColorText from "./ColorText.svelte";
 import ItemTable from "./item/ItemTable.svelte";
 
@@ -348,233 +347,228 @@ let upgrades =
     <p style="color: var(--cata-color-gray)">{singular(item.description)}</p>
   {/if}
 </section>
-<Spoiler spoily={item.id === "mon_dragon_dummy"}>
-  <div class="side-by-side">
-    <section>
-      <h1>{t("Attack", { _context, _comment: "Section heading" })}</h1>
-      <dl>
-        <dt>{t("Speed", { _context })}</dt>
-        <dd>{item.speed ?? 0}</dd>
-        <dt>{t("Melee Skill", { _context })}</dt>
-        <dd>{item.melee_skill ?? 0}</dd>
-        <dt>{t("Damage", { _context })}</dt>
-        <dd>{damage(item)}</dd>
-        {#if item.special_attacks}
-          <dt>{t("Special Attacks", { _context })}</dt>
-          <dd>
-            <ul class="no-bullets">
-              {#each item.special_attacks as special_attack}
-                <li>
-                  {#if Array.isArray(special_attack) && special_attack[0] && data.byIdMaybe("monster_attack", special_attack[0])}
-                    <ThingLink type="monster_attack" id={special_attack[0]} />
-                  {:else}
-                    <SpecialAttack {special_attack} />
-                  {/if}
-                </li>
-              {/each}
-            </ul>
-          </dd>
-        {/if}
-      </dl>
-    </section>
-    <section>
-      <h1>{t("Defense", { _context, _comment: "Section heading" })}</h1>
-      <dl style="flex: 1">
-        <dt>{t("HP", { _context })}</dt>
-        <dd>{item.hp}</dd>
-        {#if item.regenerates}
-          <dt>{t("Regenerates", { _context })}</dt>
-          <dd>{item.regenerates} hp/turn</dd>
-        {/if}
-        <dt>{t("Dodge", { _context })}</dt>
-        <dd>{item.dodge ?? 0}</dd>
-        <dt>{t("Armor", { _context })}</dt>
-        {#if item.armor}
-          <dd>
-            <dl>
-              {#each Object.entries(monsterArmor(item.armor)) as [damageTypeId, value]}
-                {@const damageType = data.byIdMaybe(
-                  "damage_type",
-                  damageTypeId
-                )}
-                {#if value}
-                  <dt>{singularName(damageType ?? { id: damageTypeId })}</dt>
-                  <dd>{value.toFixed(1)}</dd>
-                {/if}
-              {/each}
-            </dl>
-          </dd>
-        {:else}
-          <dd>
-            <dl>
-              <dt>{t("Bash", { _context: "Damage Type" })}</dt>
-              <dd>{item.armor_bash ?? 0}</dd>
-              <dt>{t("Cut", { _context: "Damage Type" })}</dt>
-              <dd>{item.armor_cut ?? 0}</dd>
-              <dt>{t("Stab", { _context: "Damage Type" })}</dt>
-              <dd>
-                {item.armor_stab ?? Math.floor((item.armor_cut ?? 0) * 0.8)}
-              </dd>
-              <dt>{t("Ballistic", { _context: "Damage Type" })}</dt>
-              <dd>{item.armor_bullet ?? 0}</dd>
-              <dt>{t("Acid", { _context: "Damage Type" })}</dt>
-              <dd>
-                {item.armor_acid ?? Math.floor((item.armor_cut ?? 0) * 0.5)}
-              </dd>
-              <dt>{t("Heat", { _context: "Damage Type" })}</dt>
-              <dd>{item.armor_fire ?? 0}</dd>
-            </dl>
-          </dd>
-        {/if}
-        {#if item.special_when_hit}
-          <dt>{t("When Hit", { _context })}</dt>
-          <dd>{item.special_when_hit[0]} ({item.special_when_hit[1]}%)</dd>
-        {/if}
-      </dl>
-    </section>
-  </div>
+<div class="side-by-side">
   <section>
-    <h1>{t("Behavior", { _context, _comment: "Section heading" })}</h1>
+    <h1>{t("Attack", { _context, _comment: "Section heading" })}</h1>
     <dl>
-      <dt
-        title="Monsters with high aggression are more likely to be hostile. Ranges from -100 to 100">
-        {t("Aggression", { _context })}
-      </dt>
-      <dd>{item.aggression ?? 0}</dd>
-      <dt title="Morale at spawn. Monsters with low morale will flee.">
-        {t("Morale", { _context })}
-      </dt>
-      <dd>{item.morale ?? 0}</dd>
-      <dt>{t("Vision Range", { _context })}</dt>
-      <dd>
-        {item.vision_day ?? 40} ({t("day", { _context })}) / {item.vision_night ??
-          1} ({t("night", { _context })})
-      </dd>
-      <dt>{t("Default Faction", { _context })}</dt>
-      <dd>{item.default_faction}</dd>
-      {#if item.anger_triggers?.length}
-        <dt>{t("Anger Triggers", { _context })}</dt>
+      <dt>{t("Speed", { _context })}</dt>
+      <dd>{item.speed ?? 0}</dd>
+      <dt>{t("Melee Skill", { _context })}</dt>
+      <dd>{item.melee_skill ?? 0}</dd>
+      <dt>{t("Damage", { _context })}</dt>
+      <dd>{damage(item)}</dd>
+      {#if item.special_attacks}
+        <dt>{t("Special Attacks", { _context })}</dt>
         <dd>
-          <ul class="comma-separated">
-            {#each item.anger_triggers as t}
-              <li><abbr title={trigger_descriptions[t]}>{t}</abbr></li>
+          <ul class="no-bullets">
+            {#each item.special_attacks as special_attack}
+              <li>
+                {#if Array.isArray(special_attack) && special_attack[0] && data.byIdMaybe("monster_attack", special_attack[0])}
+                  <ThingLink type="monster_attack" id={special_attack[0]} />
+                {:else}
+                  <SpecialAttack {special_attack} />
+                {/if}
+              </li>
             {/each}
           </ul>
-        </dd>
-      {/if}
-      {#if item.placate_triggers?.length}
-        <dt>{t("Placate Triggers", { _context })}</dt>
-        <dd>
-          <ul class="comma-separated">
-            {#each item.placate_triggers as t}
-              <li><abbr title={trigger_descriptions[t]}>{t}</abbr></li>
-            {/each}
-          </ul>
-        </dd>
-      {/if}
-      {#if item.fear_triggers?.length}
-        <dt>{t("Fear Triggers", { _context })}</dt>
-        <dd>
-          <ul class="comma-separated">
-            {#each item.fear_triggers as t}
-              <li><abbr title={trigger_descriptions[t]}>{t}</abbr></li>
-            {/each}
-          </ul>
-        </dd>
-      {/if}
-      {#if item.flags?.length}
-        <dt>{t("Flags")}</dt>
-        <dd>
-          <ul class="comma-separated">
-            {#each item.flags ?? [] as flag}
-              <li><abbr title={mon_flag_descriptions[flag]}>{flag}</abbr></li>
-            {/each}
-          </ul>
-        </dd>
-      {/if}
-      {#if item.death_function}
-        <dt>{t("On Death", { _context })}</dt>
-        <dd>
-          {#if item.death_function.effect?.id && data.byIdMaybe("SPELL", item.death_function.effect.id)}
-            {singularName(data.byId("SPELL", item.death_function.effect.id))} ({singular(
-              data.byId("SPELL", item.death_function.effect.id).description
-            )})
-          {:else}
-            {item.death_function.effect?.id ??
-              item.death_function.corpse_type ??
-              "NORMAL"}
-          {/if}
-        </dd>
-      {/if}
-      {#if upgrades}
-        <dt>{t("Upgrades Into", { _context })}</dt>
-        <dd>
-          <ul class="comma-separated or">
-            <!-- prettier-ignore -->
-            {#each upgrades.monsters as mon}<li><ThingLink type="monster" id={mon} /></li>{/each}
-          </ul>
-          {#if upgrades.age_grow}
-            {t("in {days} {days, plural, =1 {day} other {days}}", {
-              _context,
-              days: upgrades.age_grow,
-            })}
-          {:else if upgrades.half_life}
-            {t(
-              "with a half-life of {half_life} {half_life, plural, =1 {day} other {days}}",
-              { _context, half_life: upgrades.half_life }
-            )}
-          {/if}
         </dd>
       {/if}
     </dl>
   </section>
-  {#if deathDrops.size}
-    <ItemTable loot={deathDrops} heading={t("Drops")} />
-  {/if}
-  {#if harvest && (harvest.entries ?? []).length}
-    <section>
-      <h1>{t("Butchering Results", { _context })}</h1>
-      <ul>
-        {#each harvest.entries as harvest_entry}
-          {#if (harvest_entry.type && data.byIdMaybe("harvest_drop_type", harvest_entry.type)?.group) || harvest_entry.type === "bionic_group"}
-            {#each data.flattenTopLevelItemGroup(data.byId("item_group", harvest_entry.drop)) as { id, prob }}
-              <li>
-                <ItemSymbol item={data.byId("item", id)} />
-                <ThingLink type="item" {id} /> ({(prob * 100).toFixed(2)}%)
-              </li>
+  <section>
+    <h1>{t("Defense", { _context, _comment: "Section heading" })}</h1>
+    <dl style="flex: 1">
+      <dt>{t("HP", { _context })}</dt>
+      <dd>{item.hp}</dd>
+      {#if item.regenerates}
+        <dt>{t("Regenerates", { _context })}</dt>
+        <dd>{item.regenerates} hp/turn</dd>
+      {/if}
+      <dt>{t("Dodge", { _context })}</dt>
+      <dd>{item.dodge ?? 0}</dd>
+      <dt>{t("Armor", { _context })}</dt>
+      {#if item.armor}
+        <dd>
+          <dl>
+            {#each Object.entries(monsterArmor(item.armor)) as [damageTypeId, value]}
+              {@const damageType = data.byIdMaybe("damage_type", damageTypeId)}
+              {#if value}
+                <dt>{singularName(damageType ?? { id: damageTypeId })}</dt>
+                <dd>{value.toFixed(1)}</dd>
+              {/if}
             {/each}
-          {:else}
+          </dl>
+        </dd>
+      {:else}
+        <dd>
+          <dl>
+            <dt>{t("Bash", { _context: "Damage Type" })}</dt>
+            <dd>{item.armor_bash ?? 0}</dd>
+            <dt>{t("Cut", { _context: "Damage Type" })}</dt>
+            <dd>{item.armor_cut ?? 0}</dd>
+            <dt>{t("Stab", { _context: "Damage Type" })}</dt>
+            <dd>
+              {item.armor_stab ?? Math.floor((item.armor_cut ?? 0) * 0.8)}
+            </dd>
+            <dt>{t("Ballistic", { _context: "Damage Type" })}</dt>
+            <dd>{item.armor_bullet ?? 0}</dd>
+            <dt>{t("Acid", { _context: "Damage Type" })}</dt>
+            <dd>
+              {item.armor_acid ?? Math.floor((item.armor_cut ?? 0) * 0.5)}
+            </dd>
+            <dt>{t("Heat", { _context: "Damage Type" })}</dt>
+            <dd>{item.armor_fire ?? 0}</dd>
+          </dl>
+        </dd>
+      {/if}
+      {#if item.special_when_hit}
+        <dt>{t("When Hit", { _context })}</dt>
+        <dd>{item.special_when_hit[0]} ({item.special_when_hit[1]}%)</dd>
+      {/if}
+    </dl>
+  </section>
+</div>
+<section>
+  <h1>{t("Behavior", { _context, _comment: "Section heading" })}</h1>
+  <dl>
+    <dt
+      title="Monsters with high aggression are more likely to be hostile. Ranges from -100 to 100">
+      {t("Aggression", { _context })}
+    </dt>
+    <dd>{item.aggression ?? 0}</dd>
+    <dt title="Morale at spawn. Monsters with low morale will flee.">
+      {t("Morale", { _context })}
+    </dt>
+    <dd>{item.morale ?? 0}</dd>
+    <dt>{t("Vision Range", { _context })}</dt>
+    <dd>
+      {item.vision_day ?? 40} ({t("day", { _context })}) / {item.vision_night ??
+        1} ({t("night", { _context })})
+    </dd>
+    <dt>{t("Default Faction", { _context })}</dt>
+    <dd>{item.default_faction}</dd>
+    {#if item.anger_triggers?.length}
+      <dt>{t("Anger Triggers", { _context })}</dt>
+      <dd>
+        <ul class="comma-separated">
+          {#each item.anger_triggers as t}
+            <li><abbr title={trigger_descriptions[t]}>{t}</abbr></li>
+          {/each}
+        </ul>
+      </dd>
+    {/if}
+    {#if item.placate_triggers?.length}
+      <dt>{t("Placate Triggers", { _context })}</dt>
+      <dd>
+        <ul class="comma-separated">
+          {#each item.placate_triggers as t}
+            <li><abbr title={trigger_descriptions[t]}>{t}</abbr></li>
+          {/each}
+        </ul>
+      </dd>
+    {/if}
+    {#if item.fear_triggers?.length}
+      <dt>{t("Fear Triggers", { _context })}</dt>
+      <dd>
+        <ul class="comma-separated">
+          {#each item.fear_triggers as t}
+            <li><abbr title={trigger_descriptions[t]}>{t}</abbr></li>
+          {/each}
+        </ul>
+      </dd>
+    {/if}
+    {#if item.flags?.length}
+      <dt>{t("Flags")}</dt>
+      <dd>
+        <ul class="comma-separated">
+          {#each item.flags ?? [] as flag}
+            <li><abbr title={mon_flag_descriptions[flag]}>{flag}</abbr></li>
+          {/each}
+        </ul>
+      </dd>
+    {/if}
+    {#if item.death_function}
+      <dt>{t("On Death", { _context })}</dt>
+      <dd>
+        {#if item.death_function.effect?.id && data.byIdMaybe("SPELL", item.death_function.effect.id)}
+          {singularName(data.byId("SPELL", item.death_function.effect.id))} ({singular(
+            data.byId("SPELL", item.death_function.effect.id).description
+          )})
+        {:else}
+          {item.death_function.effect?.id ??
+            item.death_function.corpse_type ??
+            "NORMAL"}
+        {/if}
+      </dd>
+    {/if}
+    {#if upgrades}
+      <dt>{t("Upgrades Into", { _context })}</dt>
+      <dd>
+        <ul class="comma-separated or">
+          <!-- prettier-ignore -->
+          {#each upgrades.monsters as mon}<li><ThingLink type="monster" id={mon} /></li>{/each}
+        </ul>
+        {#if upgrades.age_grow}
+          {t("in {days} {days, plural, =1 {day} other {days}}", {
+            _context,
+            days: upgrades.age_grow,
+          })}
+        {:else if upgrades.half_life}
+          {t(
+            "with a half-life of {half_life} {half_life, plural, =1 {day} other {days}}",
+            { _context, half_life: upgrades.half_life }
+          )}
+        {/if}
+      </dd>
+    {/if}
+  </dl>
+</section>
+{#if deathDrops.size}
+  <ItemTable loot={deathDrops} heading={t("Drops")} />
+{/if}
+{#if harvest && (harvest.entries ?? []).length}
+  <section>
+    <h1>{t("Butchering Results", { _context })}</h1>
+    <ul>
+      {#each harvest.entries as harvest_entry}
+        {#if (harvest_entry.type && data.byIdMaybe("harvest_drop_type", harvest_entry.type)?.group) || harvest_entry.type === "bionic_group"}
+          {#each data.flattenTopLevelItemGroup(data.byId("item_group", harvest_entry.drop)) as { id, prob }}
             <li>
-              <ItemSymbol item={data.byId("item", harvest_entry.drop)} />
-              <ThingLink type="item" id={harvest_entry.drop} />
+              <ItemSymbol item={data.byId("item", id)} />
+              <ThingLink type="item" {id} /> ({(prob * 100).toFixed(2)}%)
             </li>
-          {/if}
-        {/each}
-      </ul>
-    </section>
-  {/if}
-  {#if dissect && (dissect.entries ?? []).length}
-    <section>
-      <h1>{t("Dissection Results", { _context })}</h1>
-      <ul>
-        {#each dissect.entries as harvest_entry}
-          {#if (harvest_entry.type && data.byId("harvest_drop_type", harvest_entry.type)?.group) || harvest_entry.type === "bionic_group"}
-            {#each data
-              .flattenTopLevelItemGroup(data.byId("item_group", harvest_entry.drop))
-              .sort((a, b) => b.prob - a.prob) as { id, prob }}
-              <li>
-                <ItemSymbol item={data.byId("item", id)} />
-                <ThingLink type="item" {id} /> ({(prob * 100).toFixed(2)}%)
-              </li>
-            {/each}
-          {:else}
+          {/each}
+        {:else}
+          <li>
+            <ItemSymbol item={data.byId("item", harvest_entry.drop)} />
+            <ThingLink type="item" id={harvest_entry.drop} />
+          </li>
+        {/if}
+      {/each}
+    </ul>
+  </section>
+{/if}
+{#if dissect && (dissect.entries ?? []).length}
+  <section>
+    <h1>{t("Dissection Results", { _context })}</h1>
+    <ul>
+      {#each dissect.entries as harvest_entry}
+        {#if (harvest_entry.type && data.byId("harvest_drop_type", harvest_entry.type)?.group) || harvest_entry.type === "bionic_group"}
+          {#each data
+            .flattenTopLevelItemGroup(data.byId("item_group", harvest_entry.drop))
+            .sort((a, b) => b.prob - a.prob) as { id, prob }}
             <li>
-              <ItemSymbol item={data.byId("item", harvest_entry.drop)} />
-              <ThingLink type="item" id={harvest_entry.drop} />
+              <ItemSymbol item={data.byId("item", id)} />
+              <ThingLink type="item" {id} /> ({(prob * 100).toFixed(2)}%)
             </li>
-          {/if}
-        {/each}
-      </ul>
-    </section>
-  {/if}
-</Spoiler>
+          {/each}
+        {:else}
+          <li>
+            <ItemSymbol item={data.byId("item", harvest_entry.drop)} />
+            <ThingLink type="item" id={harvest_entry.drop} />
+          </li>
+        {/if}
+      {/each}
+    </ul>
+  </section>
+{/if}

--- a/src/types/item/spawnLocations.ts
+++ b/src/types/item/spawnLocations.ts
@@ -1,5 +1,5 @@
 import type { CddaData } from "../../data";
-import { HIDDEN_LOOT_LOCATIONS } from "../../spoilers";
+import { isSpoilerLocation } from "../../spoilers";
 import type * as raw from "../../types";
 import { multimap } from "./utils";
 
@@ -378,7 +378,7 @@ async function computeLootByOMSAppearance(
   const lootByOMSAppearance = new Map<string, { loot: Loot; ids: string[] }>();
   await yieldable(async (relinquish) => {
     for (const [oms_id, loot] of lootByOMS.entries()) {
-      if (HIDDEN_LOOT_LOCATIONS.has(oms_id)) continue;
+      if (isSpoilerLocation(oms_id)) continue;
       const appearance = overmapAppearance(
         data,
         data.byId("overmap_special", oms_id)

--- a/src/types/item/spawnLocations.ts
+++ b/src/types/item/spawnLocations.ts
@@ -1,4 +1,5 @@
 import type { CddaData } from "../../data";
+import { HIDDEN_LOOT_LOCATIONS } from "../../spoilers";
 import type * as raw from "../../types";
 import { multimap } from "./utils";
 
@@ -338,37 +339,6 @@ export function overmapAppearance(
       : `appearance_unk`;
   }
 }
-
-const url = new URL(location.href);
-const showAll = url.searchParams.has("hideNothing");
-// Showing these is a bit spoilery, and also they are visually large, so hide them.
-const hiddenLocations = showAll
-  ? new Set()
-  : new Set([
-      "Necropolis",
-      "Isherwood Farms",
-      "lab_mutagen_6_level",
-      "Lab_SECURITY_1x1x6",
-      "Lab_CARGO_Surface",
-      "hub_01",
-      "aircraft_carrier",
-      "airliner_crashed",
-      "farm_abandoned",
-      "ranch_camp",
-      "exodii_base",
-      "Central Lab",
-      "4x4_microlab_vent_shaft",
-      "lab_subway_vent_shaft",
-      "mil_base",
-      "valhalla_cult",
-      "nuclear power plant",
-      "tutorial",
-      "debug_item_group_test",
-      "gas station bunker",
-      "bunker shop",
-      "physics_lab_LIXA",
-      "office_tower_hiddenlab",
-    ]);
 function lazily<T extends object, U>(f: (x: T) => U): (x: T) => U {
   const cache = new WeakMap<T, U>();
   return (x) => {
@@ -408,7 +378,7 @@ async function computeLootByOMSAppearance(
   const lootByOMSAppearance = new Map<string, { loot: Loot; ids: string[] }>();
   await yieldable(async (relinquish) => {
     for (const [oms_id, loot] of lootByOMS.entries()) {
-      if (hiddenLocations.has(oms_id)) continue;
+      if (HIDDEN_LOOT_LOCATIONS.has(oms_id)) continue;
       const appearance = overmapAppearance(
         data,
         data.byId("overmap_special", oms_id)


### PR DESCRIPTION
# Overview

This PR refactors spoiler handling. Specifically, it does the following:

* centralizes all spoiler IDs in a single location (`spoilers.ts`), providing an easy way to extend the system in the future
* moves the `<Spoiler />` component from `Monster.svelte` (where the check had one hardcoded ID) up to `Thing.svelte`, and uses the centralized spoiler check to hide the thing when the check returns `true`
* updates location loot display to use location IDs from the spoiler file

The overall impact of this PR is: it allows for cleaner, unified handling of all spoiler items. (The one exception to that is location loot, as I didn't want to mess with systems I don't understand too much. It should, in theory, be possible to migrate this to the ID-based spoiler check, but I haven't looked into it, as it was out of scope for this PR.)

# Related issues

Closes #214 

# Testing

Ran the dev server locally, searched a few things using default parameters (latest experimental, ASCII tileset, English language). Did **not** run the tests because they would take 10+ mins per, and I believe the manual testing (see below) should suffice.

<details>
<summary>Prefix-based hiding</summary>

<p>Default (no `?hideNothing`): "No results."</p>

<img width="1536" height="1378" alt="localhost_5173_search_f_vitrified_" src="https://github.com/user-attachments/assets/0d95caae-a8df-4e6e-8dc4-e185a34399e2" />

<p>With `?hideNothing`: all black glass items shown</p>

<img width="1536" height="1378" alt="localhost_5173_search_f_vitrified__hideNothing" src="https://github.com/user-attachments/assets/c22513dc-f718-451a-aa7a-b25dd664259d" />

</details>

<details>
<summary>ID-based hiding</summary>

<p>Default: "No results."</p>

<img width="1536" height="1378" alt="localhost_5173_search_mon_dragon_dummy" src="https://github.com/user-attachments/assets/bd9f46e7-f826-43d4-ba90-69372ca773a2" />

<p>With `?hideNothing`: ancient red dragon</p>

<img width="1536" height="1378" alt="localhost_5173_search_f_vitrified__hideNothing (1)" src="https://github.com/user-attachments/assets/3844641f-6554-4386-8457-09dc26f10b78" />

</details>

<details>
<summary>Suffix-based hiding</summary>

<p>(The suffix check is more of a futureproofing than an immediate need. I had to use the full item ID to check it because `_vitrified` is a catch-all for the current black-glass items.)

<p>Default: "No results."</p>

<img width="1540" height="1378" alt="localhost_5173_search_t_tree_apple_vitrified" src="https://github.com/user-attachments/assets/4c573762-3063-4b7c-9894-294681c54258" />

<p>With `?hideNothing`: tree of glass apples</p>

<img width="1540" height="1378" alt="localhost_5173_search__vitrified_hideNothing" src="https://github.com/user-attachments/assets/208b4d57-3dd1-43ad-9458-609bd960f0fe" />

</details>

<details>
<summary>Items that shouldn't be hidden</summary>

<p>Default: all relevant items shown</p>

<img width="1540" height="1378" alt="localhost_5173_search_ar-15" src="https://github.com/user-attachments/assets/b059a69a-86ef-4632-a40d-753ec033cded" />

<p>With `?hideNothing`: all relevant items still shown</p>

<img width="1540" height="1378" alt="localhost_5173_search_ar-15_hideNothing" src="https://github.com/user-attachments/assets/0d8838ee-3bb3-4d9c-86f4-b1542330e9a8" />

</details>

<details>
<summary>Locations to hide loot from</summary>

<p>Location itself (`mil_base`) is accessible in search</p>

<img width="1540" height="1378" alt="localhost_5173_search_t_tree_apple_vitrified (1)" src="https://github.com/user-attachments/assets/e2c9269f-35aa-4b13-9d08-3668377fcc74" />

<p>Loot from location (checked `9mmP`) does not appear on the list (hard to showcase since the viewport would not include the search menu no matter how hard I tried)</p>

</details>